### PR TITLE
fix test issues due to email case

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: 🚀 Deploy
+name: 🚀 CI
 on:
   push:
     branches:

--- a/app/utils/auth.server.ts
+++ b/app/utils/auth.server.ts
@@ -5,7 +5,7 @@ import { Authenticator } from 'remix-auth'
 import { safeRedirect } from 'remix-utils/safe-redirect'
 import { connectionSessionStorage, providers } from './connections.server.ts'
 import { prisma } from './db.server.ts'
-import { capitalizeFirstLetter, combineHeaders, downloadFile } from './misc.tsx'
+import { combineHeaders, downloadFile } from './misc.tsx'
 import { type ProviderUser } from './providers/provider.ts'
 import { authSessionStorage } from './session.server.ts'
 
@@ -77,10 +77,7 @@ export async function login({
 	email: User['email']
 	password: string
 }) {
-	const user = await verifyUserPassword(
-		{ email: email.toLowerCase() },
-		password,
-	)
+	const user = await verifyUserPassword({ email }, password)
 	if (!user) return null
 	const session = await prisma.session.create({
 		select: { id: true, expirationDate: true, userId: true },
@@ -125,9 +122,9 @@ export async function signup({
 			expirationDate: getSessionExpirationDate(),
 			user: {
 				create: {
-					email: email.toLowerCase(),
-					firstName: capitalizeFirstLetter(firstName.toLowerCase()),
-					lastName: capitalizeFirstLetter(lastName.toLowerCase()),
+					email,
+					firstName,
+					lastName,
 					roles: { connect: { name: 'user' } },
 					password: {
 						create: {
@@ -163,9 +160,9 @@ export async function signupWithConnection({
 			expirationDate: getSessionExpirationDate(),
 			user: {
 				create: {
-					email: email.toLowerCase(),
-					firstName: capitalizeFirstLetter(firstName.toLowerCase()),
-					lastName: capitalizeFirstLetter(lastName.toLowerCase()),
+					email,
+					firstName,
+					lastName,
 					roles: { connect: { name: 'user' } },
 					connections: { create: { providerId, providerName } },
 					image: imageUrl

--- a/app/utils/user-validation.ts
+++ b/app/utils/user-validation.ts
@@ -1,13 +1,17 @@
 import { z } from 'zod'
+import { capitalizeFirstLetter } from './misc'
 
 export const PasswordSchema = z
 	.string({ required_error: 'Password is required' })
 	.min(6, { message: 'Password must be at least 6 characters' })
 	.max(100, { message: 'Password is too long' })
+
 export const NameSchema = z
 	.string({ required_error: 'Name is required' })
 	.min(3, { message: 'Name is too short' })
 	.max(40, { message: 'Name is too long' })
+	.transform(value => capitalizeFirstLetter(value.trim().toLowerCase()))
+
 export const EmailSchema = z
 	.string({ required_error: 'Email is required' })
 	.email({ message: 'Email is invalid' })

--- a/tests/db-utils.ts
+++ b/tests/db-utils.ts
@@ -6,7 +6,8 @@ import bcrypt from 'bcryptjs'
 export function createUser() {
 	const firstName = faker.person.firstName()
 	const lastName = faker.person.lastName()
-	const email = faker.internet.email({ firstName, lastName })
+	// In the app, we always lowercase the email via schema validation but in e2e tests we sometimes bypass schema validation and do db operations directly. Use lower case email to avoid case sensitivity issues.
+	const email = faker.internet.email({ firstName, lastName }).toLowerCase()
 
 	return { firstName, lastName, email }
 }

--- a/tests/mocks/utils.ts
+++ b/tests/mocks/utils.ts
@@ -42,7 +42,7 @@ export async function requireEmail(recipient: string) {
 
 export async function readEmail(recipient: string) {
 	try {
-		const email = await readFixture('email', recipient)
+		const email = await readFixture('email', recipient.toLowerCase())
 		return EmailSchema.parse(email)
 	} catch (error) {
 		console.error(`Error reading email`, error)


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
In the app, we always lowercase the email via schema validation but in e2e tests we sometimes bypass schema validation and do db operations directly. Use lower case email to avoid case sensitivity issues.

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
